### PR TITLE
Remove Deprecated `organization` Parameter from API Calls

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -45,7 +45,7 @@ async function run() {
 
                 if(long_live_branches){
                     let settings = new Settings()
-                    await settings.setLongLiveBranches(sonarToken,sonarOrganization,serviceKey,long_live_branches)
+                    await settings.setLongLiveBranches(sonarToken,serviceKey,long_live_branches)
                 }
             }
         }

--- a/src/libs/settings.ts
+++ b/src/libs/settings.ts
@@ -5,8 +5,8 @@ export class Settings{
     constructor(){
         this.baseURL = "https://sonarcloud.io";
     }
-    async setLongLiveBranches(sonarToken:string|undefined, sonarOrganization: string|undefined ,serviceName: string|undefined,longlivebranches: string|undefined){
-        const setLongLiveBranches: string = `${this.baseURL}/api/settings/set?organization=${sonarOrganization}&component=${serviceName}&key=sonar.branch.longLivedBranches.regex&value=${longlivebranches}`;
+    async setLongLiveBranches(sonarToken:string|undefined,serviceName: string|undefined,longlivebranches: string|undefined){
+        const setLongLiveBranches: string = `${this.baseURL}/api/settings/set?component=${serviceName}&key=sonar.branch.longLivedBranches.regex&value=${longlivebranches}`;
         const base64_token: string = Buffer.from(sonarToken+':').toString('base64')
         await fetch(setLongLiveBranches, {
             method: 'POST',

--- a/src/task.json
+++ b/src/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 3
+        "Patch": 4
     },
     "visibility": [
         "Release",

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "module": "CommonJS",
+    "types": ["jest"],
     "moduleResolution": "Node",
     "esModuleInterop": true,
     "target": "ES6",

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "sonarcloud-create-project",
     "name": "SonarCloud create project",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "publisher": "hendamm",
     "public": true,
     "repository": {


### PR DESCRIPTION
**PR Description**

**Summary**
This PR removes the `organization` parameter from API calls, as the API has been updated and no longer allows this parameter if component is sended.

**Problem Addressed**
The API was recently updated and no longer accepts the `organization` parameter, causing errors in current requests that include this parameter. This PR fixes this issue by removing the `organization` parameter from all API calls.

![image](https://github.com/henryd24/azdevops-sonarcloud-create-project/assets/35784433/5230e907-cb60-4c45-a7b5-1d4d5911c45c)

**Main Changes**
- Remove the `organization` parameter from all API calls in the codebase.
- Update the extension version.
